### PR TITLE
Search for train-stop type instead of name

### DIFF
--- a/mod/control.lua
+++ b/mod/control.lua
@@ -104,7 +104,7 @@ function mapshot(player, params)
 
   -- Find train stations
   local stations = {}
-  for _, ent in ipairs(surface.find_entities_filtered({area=area, name="train-stop"})) do
+  for _, ent in ipairs(surface.find_entities_filtered({area=area, type="train-stop"})) do
     table.insert(stations, {
       backer_name = ent.backer_name,
       bounding_box = ent.bounding_box,


### PR DESCRIPTION
By using `type = "train-stop"` instead of `name = "train-stop"` this will now also include modded train stops, like those from LTN. 

Reason for making this change is because I noticed I had no train stops on my map whatsoever, because it did not include the logistic-train-stop from LTN.