### PR TITLE
Fix for API changes in 2.0 and Space Age

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.23
+Date: 2024.10.22
+  Bug:
+    - Fix for API changes in Space Age
+    - Some methods have moved from LuaGameScript class to LuaHelpers  and LuaBootstrap 
+
+---------------------------------------------------------------------------------------------------
 Version: 0.0.22
 Date: 2024.04.15
   Bug:

--- a/embed/regen.go
+++ b/embed/regen.go
@@ -73,7 +73,7 @@ func genLua(viewerFiles []*FileInfo, version, versionHash string) {
 
 		if fi.Binary {
 			content := factorio.Encode(fi.Content)
-			writeLn(fmt.Sprintf(`data.files[%q] = function() return game.decode_string(table.concat({`, key))
+			writeLn(fmt.Sprintf(`data.files[%q] = function() return helpers.decode_string(table.concat({`, key))
 			begin := 0
 			end := 78
 			for begin < len(content) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapshot",
-  "version": "0.0.16",
+  "version": "0.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mapshot",
-      "version": "0.0.16",
+      "version": "0.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/leaflet": "^1.5.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapshot",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Web frontend for Mapshot, a Factorio screenshot generator.",
   "main": "index.js",
   "scripts": {

--- a/mod/control.lua
+++ b/mod/control.lua
@@ -21,7 +21,7 @@ function build_params(player)
     params.surface = all_surfaces
   end
 
-  for k,v in pairs(game.json_to_table(overrides)) do
+  for k,v in pairs(helpers.json_to_table(overrides)) do
     params[k] = v
   end
 
@@ -85,16 +85,16 @@ function mapshot(params)
   end
 
   -- collect game version and active mod versions
-  local game_version = game.active_mods["base"]
+  local game_version = script.active_mods["base"]
   local active_mods = {}
-  for name, version in pairs(game.active_mods) do
+  for name, version in pairs(script.active_mods) do
     if name ~= "base" then
       active_mods[name] = version
     end
   end
 
   -- Write metadata.
-  game.write_file(data_prefix .. "mapshot.json", game.table_to_json({
+  helpers.write_file(data_prefix .. "mapshot.json", helpers.table_to_json({
     savename = params.savename,
     unique_id = unique_id,
     map_id = map_id,
@@ -114,9 +114,9 @@ function mapshot(params)
       local config = {
         path = data_dir,
       }
-      content = string.gsub(content, "__MAPSHOT_CONFIG_TOKEN__", game.table_to_json(config))
+      content = string.gsub(content, "__MAPSHOT_CONFIG_TOKEN__", helpers.table_to_json(config))
     end
-    local r = game.write_file(prefix .. fname, content)
+    local r = helpers.write_file(prefix .. fname, content)
   end
 
   -- Generate all the tiles.
@@ -355,7 +355,7 @@ script.on_event(defines.events.on_tick, function(evt)
     script.on_event(defines.events.on_tick, function(evt)
       log("marking as done @" .. evt.tick)
       script.on_event(defines.events.on_tick, nil)
-      game.write_file("mapshot-done-" .. params.onstartup, data_prefix)
+      helpers.write_file("mapshot-done-" .. params.onstartup, data_prefix)
     end)
   end
 end)

--- a/mod/info.json
+++ b/mod/info.json
@@ -1,11 +1,11 @@
 {
   "name": "mapshot",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "title": "Mapshot",
   "author": "pierre@palatin.fr",
-  "factorio_version": "1.1",
+  "factorio_version": "2.0",
   "dependencies": [
-    "base >= 1.0"
+    "base >= 2.0"
   ],
   "description": "Generates a zoomable render of the whole map."
 }


### PR DESCRIPTION
These changes  appear to have got it working for Factorio 2.0 and the Space Age DLC.

Some API methods were moved from LuaGameScript class to LuaHelpers  and LuaBootstrap.