### PR TITLE
Switch to string enum for surface types

### DIFF
--- a/frontend/common.ts
+++ b/frontend/common.ts
@@ -78,10 +78,10 @@ export interface MapshotSurfaceJSON {
     // The localised name of this surface. If it's a planet or a space platform,
     // then the corresponding name is used here instead.
     surface_localised_name?: string,
-    // Is this surface a planet?
-    is_planet?: boolean,
-    // Is this surface a space platform?
-    is_space_platform?: boolean,
+
+    // The type of surface this is.
+    // Defaults to unkown, unless a planet or platform is attached to the surface.
+    surface_type?: "planet" | "platform" | "unknown",
 
     // Prefix for where to find the tile file.
     file_prefix: string,

--- a/mod/control.lua
+++ b/mod/control.lua
@@ -272,17 +272,16 @@ function gen_surface_info(params, surface)
     end
   end
 
+  local surface_type = "unknown"
   local localised_name = surface.localised_name
 
-  local is_planet = false
   if surface.planet ~= nil then
-    is_planet = true
+    surface_type = "planet"
     localised_name = surface.planet.name
   end
 
-  local is_space_platform = false
   if surface.platform ~= nil then
-    is_space_platform = true
+    surface_type = "platform"
     localised_name = surface.platform.name
   end
 
@@ -290,8 +289,7 @@ function gen_surface_info(params, surface)
     surface_name = surface.name,
     surface_idx = surface.index,
     surface_localised_name = localised_name,
-    is_planet = is_planet,
-    is_space_platform = is_space_platform,
+    surface_type = surface_type,
     file_prefix = "s" .. surface.index .. "zoom_",
     tile_size = math.pow(2, tile_range_max),
     render_size = render_size,


### PR DESCRIPTION
Per the comment on #64, I thought I'd submit this for consideration. I'm always open and receptive to changes.

A few sample surfaces from the generated `d-XX/mapshot.json`:

```
"surface_name": "fulgora",
"surface_localised_name": "fulgora",
"surface_type": "planet",

"surface_name": "platform-4",
"surface_localised_name": "[item=copper-plate] item name",
"surface_type": "platform",

// created via game.create_surface("some-mod-surface")
"surface_name": "some-mod-surface",
"surface_type": "unknown",
// no localised_name
```
